### PR TITLE
F/dumpbackslash

### DIFF
--- a/data/ml/concepts/concepts_train_logistic.py
+++ b/data/ml/concepts/concepts_train_logistic.py
@@ -36,13 +36,24 @@ class Concept:
     def from_q(qconc, is_valid):
         return Concept(qconc['fullLabel'], [float(qconc[f]) for f in feats], int(is_valid))
 
+def list_to_dict(questions):
+    d= {}
+    for question in questions:
+        d[question["qId"]]=question
+    return d
 
 def load(input_list, gold_standard):
     concepts = []
     correct_counter = 0
     incorrect_counter = 0
-    for q, q_gs in zip(input_list, gold_standard):
-        assert q['qId'] == q_gs['qId']
+    input_dict = list_to_dict(input_list)
+    gold_standard_dict = list_to_dict(gold_standard)
+
+    common_concepts = set(input_dict.keys()).intersection(set(gold_standard_dict))
+
+    for qId in common_concepts:
+        q=input_dict[qId]
+        q_gs = gold_standard_dict[qId]
         for conc in q['Concept']:
             valid = False
             for corr in q_gs['Concept']:

--- a/data/ml/concepts/concepts_train_logistic.py
+++ b/data/ml/concepts/concepts_train_logistic.py
@@ -49,7 +49,7 @@ def load(input_list, gold_standard):
     input_dict = list_to_dict(input_list)
     gold_standard_dict = list_to_dict(gold_standard)
 
-    common_concepts = set(input_dict.keys()).intersection(set(gold_standard_dict))
+    common_concepts = set(input_dict.keys()) & (set(gold_standard_dict))
 
     for qId in common_concepts:
         q=input_dict[qId]

--- a/src/main/java/cz/brmlab/yodaqa/analysis/question/ConceptClassifier.java
+++ b/src/main/java/cz/brmlab/yodaqa/analysis/question/ConceptClassifier.java
@@ -15,37 +15,39 @@ import cz.brmlab.yodaqa.model.Question.Concept;
 public class ConceptClassifier {
 	/* N.B. This is trained on the moviesC-train dataset,
 	 * not on curated or anything! */
-	/* Training data - correct: 671 (11.571%), incorrect: 5128 (88.429%) */
+
+	/* Training data - correct: 1163 (10.207%), incorrect: 10231 (89.793%) */
 
 	/* 10-fold cross-validation (with 0.20 test splits): */
-	/* CV fold precision 93.534% (1085/1160) */
-	/* CV fold precision 94.483% (1096/1160) */
-	/* CV fold precision 93.276% (1082/1160) */
-	/* CV fold precision 94.224% (1093/1160) */
-	/* CV fold precision 94.052% (1091/1160) */
-	/* CV fold precision 95.000% (1102/1160) */
-	/* CV fold precision 94.483% (1096/1160) */
-	/* CV fold precision 95.259% (1105/1160) */
-	/* CV fold precision 94.828% (1100/1160) */
-	/* CV fold precision 93.448% (1084/1160) */
-	/* === CV average precision 94.259% (+-SD 0.645%) */
+	/* CV fold precision 93.857% (2139/2279) */
+	/* CV fold precision 95.437% (2175/2279) */
+	/* CV fold precision 95.305% (2172/2279) */
+	/* CV fold precision 93.550% (2132/2279) */
+	/* CV fold precision 94.559% (2155/2279) */
+	/* CV fold precision 94.603% (2156/2279) */
+	/* CV fold precision 95.086% (2167/2279) */
+	/* CV fold precision 94.954% (2164/2279) */
+	/* CV fold precision 94.208% (2147/2279) */
+	/* CV fold precision 94.559% (2155/2279) */
+	/* === CV average precision 94.612% (+-SD 0.580%) */
 
-	/* Training set precision 94.378% (5473/5799) */
+	/* Training set precision 94.734% (10794/11394) */
 	/* Model (trained on the whole training set): */
 	double[] weights = {
-		0.248860, // editDist
-		4.457111, // labelProbability
-		0.577820, // logPopularity
-		4.231233, // relatedness
-		-1.064028, // getByLAT
-		0.683527, // getByNE
-		0.491508, // getBySubject
+		0.044246, // editDist
+		4.671980, // labelProbability
+		0.467709, // logPopularity
+		4.503668, // relatedness
+		-2.432906, // getByLAT
+		0.318891, // getByNE
+		0.059543, // getBySubject
 		0.000000, // getByNgram
-		1.178016, // getByFuzzyLookup
-		-1.393301, // getByCWLookup
+		0.941107, // getByFuzzyLookup
+		-1.713363, // getByCWLookup
 	};
-	double intercept = -7.214133;
-	
+	double intercept = -6.264199;
+
+
 	public double calculateProbability(JCas questionView, Concept l) {
 		List<String> qtoks = ConceptGloVeScoring.questionRepr(questionView);
 		List<String> desctoks;

--- a/src/main/java/cz/brmlab/yodaqa/io/debug/QuestionPrinter.java
+++ b/src/main/java/cz/brmlab/yodaqa/io/debug/QuestionPrinter.java
@@ -142,7 +142,7 @@ public class QuestionPrinter extends JCasConsumer_ImplBase {
 			Concepttmp += "\"logPopularity\": " + c.getLogPopularity() + ", ";
 			Concepttmp += "\"score\": " + c.getScore() + ", ";
 			if (c.getDescription() != null)
-				Concepttmp += "\"description\": \"" + c.getDescription().replaceAll("\"", "\\\\\"") + "\", ";
+				Concepttmp += "\"description\": \"" + c.getDescription().replaceAll("\\", "\\\\\\\\").replaceAll("\"", "\\\\\"") + "\", ";
 			Concepttmp += "\"relatedness\": " + c.getRelatedness() + ", ";
 			Concepttmp += "\"getByLAT\": " + (c.getByLAT() ? 1 : 0) + ", ";
 			Concepttmp += "\"getByNE\": " + (c.getByNE() ? 1 : 0) + ", ";

--- a/src/main/java/cz/brmlab/yodaqa/io/debug/QuestionPrinter.java
+++ b/src/main/java/cz/brmlab/yodaqa/io/debug/QuestionPrinter.java
@@ -141,8 +141,9 @@ public class QuestionPrinter extends JCasConsumer_ImplBase {
 			Concepttmp += "\"labelProbability\": " + c.getLabelProbability() + ", ";
 			Concepttmp += "\"logPopularity\": " + c.getLogPopularity() + ", ";
 			Concepttmp += "\"score\": " + c.getScore() + ", ";
-			if (c.getDescription() != null)
-				Concepttmp += "\"description\": \"" + c.getDescription().replaceAll("\\", "\\\\\\\\").replaceAll("\"", "\\\\\"") + "\", ";
+			if (c.getDescription() != null){
+				Concepttmp += "\"description\": \"" + c.getDescription().replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"") + "\", ";
+			}
 			Concepttmp += "\"relatedness\": " + c.getRelatedness() + ", ";
 			Concepttmp += "\"getByLAT\": " + (c.getByLAT() ? 1 : 0) + ", ";
 			Concepttmp += "\"getByNE\": " + (c.getByNE() ? 1 : 0) + ", ";


### PR DESCRIPTION
I had trouble with regenerating synthetic questions - Most of questions were same, but it produced about 20 questions differently (I do not know why). I made it so it doesn't matter: scripts that using several datasets (train.json, questionDump, tsv file...) will just make intersection of these datasets and use questions that are in all of them. (This is what, in commit messages, I call "robustness").

Bad thing about that is that it is not clear what dataset is really used, etc.

----

Bug in question dumper should be fixed now.