### PR TITLE
Fixing squid:S2131, Fixing squid:S2184

### DIFF
--- a/src/main/java/approxlib/util/FormatUtilities.java
+++ b/src/main/java/approxlib/util/FormatUtilities.java
@@ -325,7 +325,7 @@ public class FormatUtilities {
 	public static String escapeLatex(String s) {
 		StringBuffer sb = new StringBuffer();
 		for (int i = 0; i < s.length(); i++) {
-			String c = s.charAt(i) + "";
+			String c = Character.toString(s.charAt(i));
 			if (c.equals("#")) {
 				c = "\\#";
 			}

--- a/src/main/java/cz/brmlab/yodaqa/analysis/ansscore/AnswerScoreSimple.java
+++ b/src/main/java/cz/brmlab/yodaqa/analysis/ansscore/AnswerScoreSimple.java
@@ -54,7 +54,7 @@ public class AnswerScoreSimple extends JCasAnnotator_ImplBase {
 		if (fv.isFeatureSet(AF.PassageLogScore))
 			passageLogScore = fv.getFeatureValue(AF.PassageLogScore);
 		else if (fv.getFeatureValue(AF.OriginDocTitle) > 0.0)
-			passageLogScore = Math.log(1 + 2);
+			passageLogScore = (double)Math.log(1 + 2);
 
 		double neBonus = 0;
 		if (fv.isFeatureSet(AF.OriginPsgNE))

--- a/src/main/java/cz/brmlab/yodaqa/flow/asb/MultiThreadASB.java
+++ b/src/main/java/cz/brmlab/yodaqa/flow/asb/MultiThreadASB.java
@@ -682,7 +682,7 @@ public class MultiThreadASB extends Resource_ImplBase implements ASB {
 	    long wait_start = System.currentTimeMillis();
 	    int timeout_s = 5*60;
 
-            finishedJobs.wait(timeout_s * 1000);
+            finishedJobs.wait((long)timeout_s * 1000);
 
 	    if (! (finishedJobs.get() == 0 && System.currentTimeMillis() - wait_start >= (timeout_s-1) * 1000))
               continue;

--- a/src/main/java/cz/brmlab/yodaqa/io/collection/GoldStandardAnswerPrinter.java
+++ b/src/main/java/cz/brmlab/yodaqa/io/collection/GoldStandardAnswerPrinter.java
@@ -125,7 +125,7 @@ public class GoldStandardAnswerPrinter extends JCasConsumer_ImplBase {
 
 			double score = 0.0;
 			if (match >= 0)
-				score = 1.0 - Math.log(1 + match) / Math.log(i);
+				score = 1.0 - Math.log(1 + match) / (double)Math.log(i);
 
 			output(qi, procTime, score, match, i, matchText, toplist);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule  " squid:S2131 -  Primitives should not be boxed just for "String" conversion, squid:S2184 -  Math operands should be cast before assignment". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S2184


Please let me know if you have any questions.
Sameer Misger