### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/approxlib/distance/TreeDist.java
+++ b/src/main/java/approxlib/distance/TreeDist.java
@@ -41,7 +41,7 @@ public abstract class TreeDist {
 
 	@Override
 	public String toString() {
-		String strNorm = (this.isNormalized() ? "(normalized)" : "(not normalized)");
+		String strNorm = this.isNormalized() ? "(normalized)" : "(not normalized)";
 		return this.getClass().getSimpleName() + strNorm;
 	}
 

--- a/src/main/java/approxlib/tree/LblTree.java
+++ b/src/main/java/approxlib/tree/LblTree.java
@@ -184,7 +184,7 @@ public class LblTree extends DefaultMutableTreeNode implements Comparable {
 		if (parents == 0) {
 			return 0.0;
 		} else {
-			return ((double)children / (double)parents);
+			return (double)children / (double)parents;
 		}
 	}
 	
@@ -392,7 +392,7 @@ public class LblTree extends DefaultMutableTreeNode implements Comparable {
 			return true;
 		} else if (cmp > 0) {
 			if (!isRoot()) {
-				LblTree parent = ((LblTree)this.getParent()); 
+				LblTree parent = (LblTree)this.getParent(); 
 				int i = parent.getIndex(this);     // slow, as getIndex() performs linear search in children array
 				parent.insert(p, i);
 				return true;

--- a/src/main/java/approxlib/util/FormatUtilities.java
+++ b/src/main/java/approxlib/util/FormatUtilities.java
@@ -77,7 +77,7 @@ public class FormatUtilities {
 		for (int i = 0; i < parse.length; i++) {
 			parse[i] = stripQuotes(parse[i], quote);
 		}
-		return (parse);
+		return parse;
 	}
 	
 	public static String stripQuotes(String s, char quote) {

--- a/src/main/java/cz/brmlab/yodaqa/analysis/ansscore/AnswerScoreDecisionForest.java
+++ b/src/main/java/cz/brmlab/yodaqa/analysis/ansscore/AnswerScoreDecisionForest.java
@@ -137,7 +137,7 @@ public class AnswerScoreDecisionForest extends JCasAnnotator_ImplBase {
 			for(Tree t: model.forest) {
 				res += model.learning_rate*classifyWithOneTree(fvec, t, 0);
 			}
-			res = (1.0/(1.0 + Math.exp(-res)));
+			res = 1.0/(1.0 + Math.exp(-res));
 			answers.add(new AnswerScore(a, res));
 		}
 

--- a/src/main/java/cz/brmlab/yodaqa/analysis/answer/AnswerClueOverlap.java
+++ b/src/main/java/cz/brmlab/yodaqa/analysis/answer/AnswerClueOverlap.java
@@ -81,7 +81,7 @@ public class AnswerClueOverlap extends JCasAnnotator_ImplBase {
 		matchClues(ai, questionView, answerView,
 				new ClueFilter() {
 					public boolean test(Clue c) {
-						return (c instanceof ClueNE || c instanceof ClueConcept);
+						return c instanceof ClueNE || c instanceof ClueConcept;
 					}
 				},
 				AF.ClOCMatchScore,

--- a/src/main/java/cz/brmlab/yodaqa/flow/asb/MultiThreadASB.java
+++ b/src/main/java/cz/brmlab/yodaqa/flow/asb/MultiThreadASB.java
@@ -509,7 +509,7 @@ public class MultiThreadASB extends Resource_ImplBase implements ASB {
       try {
         if (nextCas == null)
           nextCas = processUntilNextOutputCas();
-        return (nextCas != null);
+        return nextCas != null;
       } finally {
         timer.stopIt();
         getMBean().reportAnalysisTime(timer.getDuration());

--- a/src/main/java/cz/brmlab/yodaqa/io/web/WebAnswerPrinter.java
+++ b/src/main/java/cz/brmlab/yodaqa/io/web/WebAnswerPrinter.java
@@ -47,7 +47,7 @@ public class WebAnswerPrinter extends JCasConsumer_ImplBase {
 		FSIterator answerit = idx.iterator();
 		List<QuestionAnswer> answers = new ArrayList<>();
 		while (answerit.hasNext()) {
-			Answer a = ((Answer) answerit.next());
+			Answer a = (Answer) answerit.next();
 			QuestionAnswer qa = new QuestionAnswer(a.getText(), a.getConfidence(), a.getAnswerID());
 			if (a.getSnippetIDs() != null) { //AnsweringSnippet ID should never be null
 				for (Integer PassageID : a.getSnippetIDs().toArray()) {

--- a/src/main/java/cz/brmlab/yodaqa/pipeline/AnswerCASMerger.java
+++ b/src/main/java/cz/brmlab/yodaqa/pipeline/AnswerCASMerger.java
@@ -189,7 +189,7 @@ public class AnswerCASMerger extends JCasMultiplier_ImplBase {
 			needALasts.put(o, need);
 		}
 		// logger.debug("in: {} resultIsLast {}, alasts {} < {}", o, ri.getIsLast(), seen, need);
-		return (need > 0 && seen >= need);
+		return need > 0 && seen >= need;
 	}
 
 	/** Convert given AnswerCAS to an Answer FS in an AnswerHitlistCAS. */

--- a/src/main/java/cz/brmlab/yodaqa/pipeline/solrfull/BingFullPrimarySearch.java
+++ b/src/main/java/cz/brmlab/yodaqa/pipeline/solrfull/BingFullPrimarySearch.java
@@ -211,7 +211,7 @@ public class BingFullPrimarySearch extends JCasMultiplier_ImplBase {
 			jcas.createView("Result");
 			JCas resultView = jcas.getView("Result");
 			if (result != null) {
-				boolean isLast = (i == results.size());
+				boolean isLast = i == results.size();
 				ResultInfo ri = generateBingResult(questionView, resultView, result, isLast ? i : 0);
 				String title = ri.getDocumentTitle();
 				logger.info(" ** SearchResultCAS: " + ri.getDocumentId() + " " + (title != null ? title : ""));

--- a/src/main/java/cz/brmlab/yodaqa/pipeline/solrfull/SolrFullPrimarySearch.java
+++ b/src/main/java/cz/brmlab/yodaqa/pipeline/solrfull/SolrFullPrimarySearch.java
@@ -219,7 +219,7 @@ public class SolrFullPrimarySearch extends JCasMultiplier_ImplBase {
 			jcas.createView("Result");
 			JCas resultView = jcas.getView("Result");
 			if (result != null) {
-				boolean isLast = (i == results.size());
+				boolean isLast = i == results.size();
 				ResultInfo ri = generateSolrResult(questionView, resultView, result, isLast ? i : 0);
 				String title = ri.getDocumentTitle();
 				logger.info(" ** SearchResultCAS: " + ri.getDocumentId() + " " + (title != null ? title : ""));

--- a/src/main/java/cz/brmlab/yodaqa/provider/solr/Solr.java
+++ b/src/main/java/cz/brmlab/yodaqa/provider/solr/Solr.java
@@ -212,7 +212,7 @@ public class Solr implements Closeable {
 		int finalDist = settings.getProximityBaseDist()
 			* ((int) Math.pow(settings.getProximityBaseFactor(), degree))
 			* n_terms;
-		double finalWeight = (sumWeight / Math.pow(2, degree));
+		double finalWeight = sumWeight / Math.pow(2, degree);
 		result.append("\"~" + finalDist + ")^" + finalWeight);
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " squid:UselessParenthesesCheck -  Useless parentheses around expressions should be removed to prevent any misunderstanding". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck


Please let me know if you have any questions.
Sameer Misger